### PR TITLE
Detect changes even when the file size remains constant (fix typo)

### DIFF
--- a/lib/watchr.coffee
+++ b/lib/watchr.coffee
@@ -158,7 +158,7 @@ Watcher = class
 			curr = arguments[0]
 			prev = arguments[1]
 			console.log arguments  if debug
-			return @  if curr.mtime.getTime() is prev.mtime.getTime()  or  curr.size is prev.size
+			return @  if curr.mtime.getTime() is prev.mtime.getTime()  or  curr.size isnt prev.size
 			@changed()
 			@watch()
 			return @


### PR DESCRIPTION
If you change a file from containing the string "FRED" to containing "STAN" then watchr won't pick up said change on Mac OS X because the file size doesn't change (even thought the modification timestamp does). Triggering more frequently than required is better than missing a change, I think.
