### PR TITLE
Fix unchanged detection: (mtime unchanged) AND (filesize unchanged)

### DIFF
--- a/lib/watchr.coffee
+++ b/lib/watchr.coffee
@@ -158,7 +158,7 @@ Watcher = class
 			curr = arguments[0]
 			prev = arguments[1]
 			console.log arguments  if debug
-			return @  if curr.mtime.getTime() is prev.mtime.getTime()  or  curr.size is prev.size
+			return @  if curr.mtime.getTime() is prev.mtime.getTime()  and  curr.size is prev.size
 			@changed()
 			@watch()
 			return @


### PR DESCRIPTION
watchr doesn't detect changes that don't affect filesize - e.g. changing "Stan" to "Stun". This tiny mod corrects this by switching "or" for "and".
