### PR TITLE
Add coffee-script dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
 		"type": "git",
 		"url": "http://github.com/balupton/watchr.git"
 	},
+	"dependencies" : {
+		"coffee-script" : "~1.0.0"
+	}
 	"engines" : {
 		"node": ">=0.4.0"
 	},


### PR DESCRIPTION
After I `npm install -g watchr`, running `watchr` just gives:

:; watchr 
env: coffee: No such file or directory
