### PR TITLE
Do not force users to require coffee-script

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require('coffee-script')
+
+module.exports = require('./lib/watchr');

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
 		"bal-util": "1.1.x",
 		"mocha": "0.11.x"
 	},
+	"dependencies": {
+		"coffee-script": "1.2.x"
+	},
 	"engines" : {
 		"node": ">=0.4.0"
 	},
@@ -56,5 +59,5 @@
 	"directories": {
 		"lib": "lib"
 	},
-	"main": "./lib/watchr.coffee"
+	"main": "./index.js"
 }


### PR DESCRIPTION
Watchr is a great lib, but it force us to add coffee-script in our package.json, and then to require coffee-srcipt in our js files.

```
//package.json
"dependencies": {
  "coffee-script": "~1.2.0",
  "watchr": "~1.0.0"
}

//myScript.js
require('coffee-script')
var watchr = require('watchr');
```

With this pull request you just have to require watchr, that's all.

```
//package.json
"dependencies": {
  "watchr": "~1.0.0"
}

//myScript.js
var watchr = require('watchr');
```
