### PR TITLE
watchr.watch(2 arguments) doesn't work -> make arguments parsing more flexible

### DIFF
--- a/lib/watchr.js
+++ b/lib/watchr.js
@@ -318,42 +318,50 @@ Which means you would be able to understand it, without knowing code
   })(EventEmitter);
 
   watch = function() {
-    var argOne, argTwo, args, next, options, path, watcher;
+    var arg, args, i, k, listener, options, path, watcher, _i, _j, _len, _len1, _ref;
     args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
-    if (args.length === 3) {
-      argTwo = args[1];
-      options = {};
-      if (typeof argTwo === 'function') {
-        options.listener = argTwo;
-      } else if (Array.isArray(argTwo)) {
-        options.listeners = argTwo;
-      } else if (typeof argTwo === 'object') {
-        options = argTwo;
-      }
-      options.path = args[0];
-      options.next = args[2];
-    } else if (args.length === 1) {
-      argOne = args[0];
-      if (typeof argOne === 'object') {
-        options = argOne;
-      } else {
-        options = {};
-        options.path = argOne;
+    options = {
+      listeners: []
+    };
+    path = null;
+    for (i = _i = 0, _len = args.length; _i < _len; i = ++_i) {
+      arg = args[i];
+      if (typeof arg === 'string') {
+        path = arg;
+      } else if (typeof arg === 'object') {
+        for (k in arg) {
+          options[k] = arg[k];
+        }
+      } else if (typeof arg === 'function') {
+        if (i === args.length - 1 && ((options.listener != null) || ((_ref = options.listeners) != null ? _ref.length : void 0))) {
+          options.next = arg;
+        } else {
+          options.listeners.push(arg);
+        }
+      } else if (Array.isArray(arg)) {
+        for (_j = 0, _len1 = arg.length; _j < _len1; _j++) {
+          listener = arg[_j];
+          options.listeners.push(listener);
+        }
       }
     }
+    if (path != null) {
+      options.path = path;
+    }
     path = options.path;
-    next = options.next;
+    if (path == null) {
+      throw new Error("No path specified");
+    }
     if (watchers[path] != null) {
       watcher = watchers[path];
-      if (typeof next === "function") {
-        next(null, watcher);
+      if (typeof options.next === "function") {
+        options.next(null, watcher);
       }
-      return watcher;
     } else {
       watcher = new Watcher(options);
       watchers[path] = watcher;
-      return watcher;
     }
+    return watcher;
   };
 
   module.exports = {


### PR DESCRIPTION
Sorry for the unsolicited pull request - rather than just reporting the bug I thought I'd propose a solution.

Currently the example from README.md:

```
watchr.watch(path,function(eventName,filePath,fileCurrentStat,filePreviousStat){
    console.log('a watch event occured:',arguments);
});
```

doesn't function, since it only has 2 arguments (neither 1 nor 3). Rather than writing a separate branch for the case of 2 arguments (or rewriting the 3 arguments branch), I've rewritten the arguments processing. Hopefully the code is self explanatory, and allows for much more flexible expression of intentions.

I won't be offended if you reject this pull request, it was unsolicited and is more substantial than necessary.
