### PR TITLE
Decrease watchFile polling interval

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "watchr",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "Provides a better and normalised API between Node's 0.4 watchFile and 0.6's fsWatcher",
 	"homepage": "https://github.com/bevry/watchr",
 	"keywords": [

--- a/src/lib/watchr.coffee
+++ b/src/lib/watchr.coffee
@@ -362,7 +362,7 @@ Watcher = class extends EventEmitter
 			# Watch the current file/directory
 			try
 				# Try first with fsUtil.watchFile
-				fsUtil.watchFile @path, (args...) ->
+				fsUtil.watchFile @path, interval: 100, (args...) ->
 					me.changed.apply(me,args)
 				@method = 'watchFile'
 			catch err


### PR DESCRIPTION
The default 5007ms (http://nodejs.org/api/fs.html#fs_fs_watchfile_filename_options_listener) is unusable. This reduces it to 100ms.
