### PR TITLE
Make it handle how vim saves files

### DIFF
--- a/src/lib/watchr.coffee
+++ b/src/lib/watchr.coffee
@@ -316,13 +316,27 @@ Watcher = class extends EventEmitter
 		previousStat = @stat
 		fileExists = null
 
+		# args contains what has happened
+		[event, fragment] = args
+
+		# Might be a file we don't care about
+		return if @isIgnoredPath(fragment)
+
+		# Renaming to self will fire a change event
+		if not @isDirectory
+			parts = @path.split('/')
+			filename = parts[parts.length-1]
+			if event == 'rename' and fragment == filename
+				@log('debug',"ignoring rename of #{filename} to itself")
+				return
+
 		# Log
 		@log('debug',"watch event triggered on #{@path}:", args)
 
 		# Prepare: is the same?
 		isTheSame = =>
 			if currentStat? and previousStat?
-				if currentStat.size is previousStat.size and currentStat.mtime.toString() is previousStat.mtime.toString()
+				if event != 'change' and currentStat.size is previousStat.size and currentStat.mtime.toString() is previousStat.mtime.toString()
 					return true
 			return false
 


### PR DESCRIPTION
It would appear that the way vim saves files breaks how watchr determines when something has changed.

So, my change does:
- Assumes args into listener always has [event, fragment]
- Uses isIgnoredFile on the fragment, so I can add /^4913$/ to the ignored patterns and have it ignore vim's test 4913 file (https://bugzilla.redhat.com/show_bug.cgi?id=427711)
- Says if listening on a file and the event is a rename to itself then we ignore it because a change event will happen.
- A directory is not the same if the event is a change, even if the size and mtimes are the same.

Unfortunately, I'm not entirely sure if this has any undesired side effects. I'm hoping you people will have a better idea of such things :)

Thankyou.
