### PR TITLE
Create a new watcher on a file created in place of a watched path that was moved/deleted

### DIFF
--- a/src/lib/watchr.coffee
+++ b/src/lib/watchr.coffee
@@ -399,6 +399,16 @@ Watcher = class extends EventEmitter
 
 					# Update
 					watchr.stat = currentStat = stat
+					
+					# Create a new watcher for a new file created in place of an existing one
+					if watchr.stat.birthtime > previousStat.birthtime
+						config = watchr.config;
+						config.listener = watchr.listener;
+						config.listeners = watchr.listeners;
+						
+						watchers[config.path] = null;
+						
+						createWatcher(config, next);
 
 					# Get on with it
 					return complete()


### PR DESCRIPTION
Fix/workaround for #75 