### PR TITLE
remove `--save` from installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Watchr provides a normalised API the file watching APIs of different node versio
 <h2>Install</h2>
 
 <a href="https://npmjs.com" title="npm is a package manager for javascript"><h3>NPM</h3></a><ul>
-<li>Install: <code>npm install --save watchr</code></li>
+<li>Install: <code>npm install watchr</code></li>
 <li>Module: <code>require('watchr')</code></li></ul>
 
 <h3><a href="https://github.com/bevry/editions" title="Editions are the best way to produce and consume packages you care about.">Editions</a></h3>


### PR DESCRIPTION
Purpose: 

-  fix command used for installation 

Explanation:

-  `--save` argument doesn't exist in recent npm versions anymore, it's the default behavior
-  This is the behavior as of npm 5
-  see: https://docs.npmjs.com/cli/install to check that `--save` doesn't exist
-  also see: https://stackoverflow.com/a/19578808/1311745 for verification